### PR TITLE
Comments page updated styles

### DIFF
--- a/dracula.user.css
+++ b/dracula.user.css
@@ -52,4 +52,12 @@
     body {
         background-color: #282a36;
     }
+    .commtext {
+        color: #f8f8f2
+    }
+    textarea, input {
+        background-color: #282a36;
+        color: #f8f8f2;
+        border-color: #8be9fd
+    }
 }


### PR DESCRIPTION
@leozz37 Hello! Thanks for making the Dracula theme for Hacker news!

I found that the comments page could use some love as the comment text contrast was a bit hard to read for me personally. This PR represents the style changes I made that make the comments page to make it a bit more pleasent to use while keeping it consistent with the overall theme.

Here is what the comments page looks like now:
![Screen Shot 2022-09-27 at 7 39 41 PM](https://user-images.githubusercontent.com/11841273/192610906-9b270965-65e8-4f61-a291-d833ab788463.png)

And with the suggested changes:
![Screen Shot 2022-09-27 at 7 54 57 PM](https://user-images.githubusercontent.com/11841273/192612095-f8db800b-7309-4faa-bd25-077948092052.png)

Please let me know your thoughts! This is of course a PR and doesn't need to get merged in. Simply wanted to spin up a PR as a thank you for making the style available to the public in the first place 😃 
