### PR TITLE
Update CSS for recent HN changes

### DIFF
--- a/dracula.user.css
+++ b/dracula.user.css
@@ -11,10 +11,10 @@
         background-color: #282a36;
     }
     #hnmain > tbody > tr:nth-child(1) > td {
-        background-color: #44475a;
+        background-color: #282a36;
     }
-    #hnmain > tbody > tr:nth-child(4) > td > table > tbody > tr > td {
-        background-color: #6272a4;
+    #hnmain > tbody > tr:nth-child(2) > td  {
+        background-color: #44475a;
     }
     a:link{
         color: #bd93f9;
@@ -22,7 +22,7 @@
     .hnmore a:link, a:visited {
         color: #6272a4;
     }
-    #hnmain > tbody > tr:nth-child(1) > td > table > tbody > tr > td:nth-child(2) > span > b > a {
+    #hnmain > tbody > tr:nth-child(2) > td > table > tbody > tr > td:nth-child(2) > span > b > a {
         color: #50fa7b;
     }
     .comhead a:link, .subtext a:visited {
@@ -61,3 +61,4 @@
         border-color: #8be9fd
     }
 }
+


### PR DESCRIPTION
It appears HN recently made some changes. In Chrome and Thorium I'm seeing the following when using the latest `dracula.user.css`
<img width="1255" alt="Screenshot 2024-02-08 at 12 28 56 AM" src="https://github.com/dracula/hacker-news/assets/376532/5f85b094-0dda-464d-8d41-c8223614073b">

The changes in this PR are small, and return the previous look/style:
<img width="1255" alt="Screenshot 2024-02-08 at 12 29 20 AM" src="https://github.com/dracula/hacker-news/assets/376532/853e0148-afbe-40fb-bbcf-13b7bee41d41">
